### PR TITLE
Read and log the error response body

### DIFF
--- a/plugin-gen3/auth_impl.go
+++ b/plugin-gen3/auth_impl.go
@@ -162,7 +162,7 @@ func (a Authorize) PluginAction(params map[string]string, headers map[string]*pr
 	if err != nil {
 		return errorResponse(http.StatusInternalServerError, fmt.Sprintf("error creating HTTP request to '%s': %w", url, err))
 	}
-	auth := base64.StdEncoding.EncodeToString([]byte(OidcClientId + ":" + OidcClientSecret))
+	auth := base64.StdEncoding.EncodeToString([]byte("OidcClientId" + ":" + OidcClientSecret))
 	req.Header.Add("Authorization", "Basic "+auth)
 	resp, err = httpClient.Do(req)
 	if err != nil {

--- a/plugin-gen3/auth_impl.go
+++ b/plugin-gen3/auth_impl.go
@@ -162,7 +162,7 @@ func (a Authorize) PluginAction(params map[string]string, headers map[string]*pr
 	if err != nil {
 		return errorResponse(http.StatusInternalServerError, fmt.Sprintf("error creating HTTP request to '%s': %w", url, err))
 	}
-	auth := base64.StdEncoding.EncodeToString([]byte("OidcClientId" + ":" + OidcClientSecret))
+	auth := base64.StdEncoding.EncodeToString([]byte(OidcClientId + ":" + OidcClientSecret))
 	req.Header.Add("Authorization", "Basic "+auth)
 	resp, err = httpClient.Do(req)
 	if err != nil {

--- a/plugin-gen3/auth_impl.go
+++ b/plugin-gen3/auth_impl.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -145,7 +146,8 @@ func (a Authorize) PluginAction(params map[string]string, headers map[string]*pr
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return errorResponse(int64(resp.StatusCode), fmt.Sprintf("http error from '%s': status code %d", url, resp.StatusCode))
+		body, _ := io.ReadAll(resp.Body)
+		return errorResponse(int64(resp.StatusCode), fmt.Sprintf("http error from '%s': status code %d, body: %s", url, resp.StatusCode, string(body)))
 	}
 	storageInfoResponse := new(StorageInfoResponse)
 	err = json.NewDecoder(resp.Body).Decode(storageInfoResponse)
@@ -168,7 +170,8 @@ func (a Authorize) PluginAction(params map[string]string, headers map[string]*pr
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return errorResponse(int64(resp.StatusCode), fmt.Sprintf("http error from '%s': status code %d", url, resp.StatusCode))
+		body, _ := io.ReadAll(resp.Body)
+		return errorResponse(int64(resp.StatusCode), fmt.Sprintf("http error from '%s': status code %d, body: %s", url, resp.StatusCode, string(body)))
 	}
 	accessTokenResponse := new(AccessTokenResponse)
 	err = json.NewDecoder(resp.Body).Decode(accessTokenResponse)


### PR DESCRIPTION
Tested in dev env with an invalid client ID:
> {"err":"rpc error: code = Unauthenticated desc = Plugin returned error: code: 401, message: http error from 'http://fence-service/oauth2/token?grant_type=client_credentials&scope=openid%20user': status code 401, body: {\"error\": \"invalid_client\", \"error_description\": \"The client does not exist on this server.\"}, ...}

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- Read and log error response bodies to facilitate debugging request errors

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
